### PR TITLE
Say <!here> when opening order, so Slack users get notified

### DIFF
--- a/order.rb
+++ b/order.rb
@@ -55,7 +55,7 @@ class Order
            @orders={}
            File.open('index.html','w')  {|f| f.write("") }
            if(@slack)
-             m.reply("ordering is now open @here, order with: !order foo with a shot of bar please")
+             m.reply("ordering is now open <!here>, order with: !order foo with a shot of bar please")
            else
              m.reply("ordering is now open, order with: !order foo with a shot of bar please")
            end


### PR DESCRIPTION
Slack's IRC gateway doesn't properly support the @here announcement
syntax, so work around it. Kudos to @wakamoleguy for figuring this out.

fixes 62c56dc3c2de479299bf70dbe43af55e0c8a2338