### PR TITLE
order.rb: Specify UTF-8 charset with <meta> tag

### DIFF
--- a/order.rb
+++ b/order.rb
@@ -65,7 +65,9 @@ class Order
          @open=false
          m.reply("this order has been closed")
          File.open('index.html', 'w' ) do |f|
-           f.puts "<html><head><title>coffeebot order</title></head><body>"
+           f.puts "<html><head><title>coffeebot order</title>"
+           f.puts '<meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />'
+           f.puts "</head><body>"
            @orders.each do |nick,order|
              f.puts "#{nick}: #{order}<br>"
            end


### PR DESCRIPTION
This helps display fancy apostrophes correctly.

https://stackoverflow.com/questions/2477452/%C3%A2%E2%82%AC-showing-on-page-instead-of
